### PR TITLE
Protobuf submodule pointer update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "src/main/Ecdar-ProtoBuf"]
 	path = src/main/Ecdar-ProtoBuf
-	url = git@github.com:Ecdar/Ecdar-ProtoBuf.git
-    branch = futureproof1
+	url = https://github.com/ECDAR-AAU-SW-P5/Ecdar-ProtoBuf.git

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 def grpcVersion = '1.52.1' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.17.2'
+def protobufVersion = '3.17.3'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/src/main/kotlin/TestResult.kt
+++ b/src/main/kotlin/TestResult.kt
@@ -40,6 +40,7 @@ enum class ResultType {
                 PARSING_ERROR,
                 MODEL,
                 ERROR,
+                COMPONENTSNOTINCACHE,
                 RESULT_NOT_SET -> UNSATISFIED
             }
         }


### PR DESCRIPTION
This PR updates the protobuf submodule pointer.
It now points to a commit on our forked version of the Ecdar-ProtoBuf repo.
This commit supports the cache utilization from https://github.com/ECDAR-AAU-SW-P5/Reveaal/pull/10.

Also includes small dependency update as this was required to run the tests (for me at least).

@ECDAR-AAU-SW-P5/group2 